### PR TITLE
Add rutinas route and fix template links

### DIFF
--- a/PI-main/app.py
+++ b/PI-main/app.py
@@ -354,5 +354,42 @@ def eliminar_cuenta():
     return redirect(url_for('perfil'))
 
 
+@app.route('/rutinas')
+def rutinas():
+    global racha, color_racha
+
+    rutinas_data = [
+        {
+            "id": 1,
+            "title": "Rutina de Mañana",
+            "objective": "Empieza el día con energía",
+            "img": "img/Imagen1.png",
+            "activities": [
+                "Desayuno saludable",
+                "Ejercicio ligero",
+                "Lectura matutina",
+            ],
+        },
+        {
+            "id": 2,
+            "title": "Rutina Nocturna",
+            "objective": "Relájate antes de dormir",
+            "img": "img/imagen3.png",
+            "activities": [
+                "Cenar ligero",
+                "Meditar",
+                "Leer un libro",
+            ],
+        },
+    ]
+
+    return render_template(
+        "rutinas.html",
+        rutinas=rutinas_data,
+        racha=racha,
+        color_racha=color_racha,
+    )
+
+
 if __name__ == '__main__':
     app.run(debug=True)

--- a/PI-main/templates/perfil.html
+++ b/PI-main/templates/perfil.html
@@ -19,9 +19,9 @@
                 </span>
             </button>
         </div>
-        <a href="rutinas">Rutinas</a>
+        <a href="{{ url_for('rutinas') }}">Rutinas</a>
         <img src="{{ url_for('static', filename='img/logo.png') }}" alt="Logo" class="logo-nav">
-        <a href="actividades">Actividades</a>
+        <a href="{{ url_for('actividades') }}">Actividades</a>
         <a href="{{ url_for('login') }}">Cerrar Sesión</a>
     </nav>
 

--- a/PI-main/templates/rutinas.html
+++ b/PI-main/templates/rutinas.html
@@ -39,7 +39,7 @@
             <li>{{ act }}</li>
           {% endfor %}
         </ul>
-        <a href="{{ url_for('nueva_actividad') }}?rutina_id={{ rutina.id }}" class="btn">
+        <a href="{{ url_for('NvActividad') }}?rutina_id={{ rutina.id }}" class="btn">
           Agregar a Actividades
         </a>
       </div>


### PR DESCRIPTION
## Summary
- add `/rutinas` route with sample data
- fix rutinas page link to new activity view
- use `url_for` for profile navigation links

## Testing
- `python -m py_compile PI-main/app.py PI-main/db.py PI-main/tablas/__init__.py PI-main/tablas/actividades.py PI-main/tablas/racha.py PI-main/tablas/usuarios.py`


------
https://chatgpt.com/codex/tasks/task_e_689034326f4c83288c4a8effe6ebec2a