### PR TITLE
Refactor templates with shared navbar and blueprint

### DIFF
--- a/PI-main/static/css/actividades.css
+++ b/PI-main/static/css/actividades.css
@@ -226,311 +226,39 @@ h2{
     top: 15px;
 }
 
-/* Fogata Container */
-.fogata-container {
-    display: flex;
-    align-items: center;
-    gap: 10px;
+
+.open-modal-btn {
+    background: transparent;
+    border: none;
+    padding: 0;
+    margin: 0;
+    box-shadow: none;
+    outline: none;
+    cursor: default;
 }
 
-/* Fogata Evolutiva - Estilos */
-.fogata {
-    position: relative;
-    width: 60px;
-    height: 60px;
-    transition: all 0.8s cubic-bezier(0.175, 0.885, 0.32, 1.275);
+.open-modal-btn:focus,
+.open-modal-btn:hover {
+    border: none;
+    box-shadow: none;
+    outline: none;
 }
 
-/* Contenedor de llamas */
-.llamas {
-    position: absolute;
-    bottom: 0;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 100%;
-    height: 100%;
+@keyframes fuego {
+    0%   { color: #ff5722; text-shadow: 0 0 20px #ff5722; }
+    50%  { color: #ff9800; text-shadow: 0 0 20px #ff9800; }
+    100% { color: #ff5722; text-shadow: 0 0 20px #ff5722; }
 }
-
-/* Base común para las llamas */
-.llama {
-    position: absolute;
-    bottom: 0;
-    left: 50%;
-    transform: translateX(-50%);
-    border-radius: 50% 50% 35% 35%;
-    opacity: 0.85;
-    filter: blur(1px);
-    transform-origin: bottom center;
-    transition: all 1s ease;
+.racha {
+    font-weight: bold;
+    font-size: 24px;
+    animation: fuego 1.5s infinite alternate;
 }
-
-/* Capas de fuego con diferentes formas */
-.llama-1 {
-    width: 80%;
-    height: 80%;
-    z-index: 3;
-    animation: flame1 2.5s infinite ease-in-out;
+.racha.gold {
+    color: gold;
+    animation: none;
+    text-shadow: 0 0 15px gold;
 }
-
-.llama-2 {
-    width: 70%;
-    height: 70%;
-    z-index: 4;
-    animation: flame2 2s infinite ease-in-out;
-    animation-delay: 0.3s;
-}
-
-.llama-3 {
-    width: 60%;
-    height: 60%;
-    z-index: 5;
-    animation: flame3 1.7s infinite ease-in-out;
-    animation-delay: 0.6s;
-}
-
-.llama-4 {
-    width: 50%;
-    height: 50%;
-    z-index: 6;
-    animation: flame4 1.3s infinite ease-in-out alternate;
-}
-
-/* COLORES POR ETAPA - TODAS LAS FASES */
-.fogata.etapa-0 .llama-1 { background: radial-gradient(circle at 30% 40%, #fff9c4, #ffb74d 40%, #ff7043 70%, #f4511e); }
-.fogata.etapa-0 .llama-2 { background: radial-gradient(circle at 40% 30%, #fffde7, #ffcc80 40%, #ff8a65 70%, #e64a19); }
-.fogata.etapa-0 .llama-3 { background: radial-gradient(circle at 50% 20%, #ffffff, #ffd54f 30%, #ffa726 60%, #ff6d00); }
-.fogata.etapa-0 .llama-4 { background: radial-gradient(circle at 50% 20%, #fffff0, #ffecb3 30%, #ffcc80 60%, #ff9800); }
-
-.fogata.etapa-1 .llama-1 { background: radial-gradient(circle at 30% 40%, #fff59d, #ffb74d 40%, #ff7043 70%, #f4511e); }
-.fogata.etapa-1 .llama-2 { background: radial-gradient(circle at 40% 30%, #fff8e1, #ffcc80 40%, #ff8a65 70%, #e64a19); }
-.fogata.etapa-1 .llama-3 { background: radial-gradient(circle at 50% 20%, #fffde7, #ffd54f 30%, #ffa726 60%, #ff6d00); }
-.fogata.etapa-1 .llama-4 { background: radial-gradient(circle at 50% 20%, #fff9c4, #ffecb3 30%, #ffcc80 60%, #ff9800); }
-
-.fogata.etapa-2 .llama-1 { background: radial-gradient(circle at 30% 40%, #fff176, #ffb74d 40%, #ff7043 70%, #f4511e); }
-.fogata.etapa-2 .llama-2 { background: radial-gradient(circle at 40% 30%, #fff3e0, #ffcc80 40%, #ff8a65 70%, #e64a19); }
-.fogata.etapa-2 .llama-3 { background: radial-gradient(circle at 50% 20%, #fff8e1, #ffd54f 30%, #ffa726 60%, #ff6d00); }
-.fogata.etapa-2 .llama-4 { background: radial-gradient(circle at 50% 20%, #fff59d, #ffecb3 30%, #ffcc80 60%, #ff9800); }
-
-.fogata.etapa-3 .llama-1 { background: radial-gradient(circle at 30% 40%, #ffee58, #ffb74d 40%, #ff7043 70%, #f4511e); }
-.fogata.etapa-3 .llama-2 { background: radial-gradient(circle at 40% 30%, #ffecb3, #ffcc80 40%, #ff8a65 70%, #e64a19); }
-.fogata.etapa-3 .llama-3 { background: radial-gradient(circle at 50% 20%, #fff3e0, #ffd54f 30%, #ffa726 60%, #ff6d00); }
-.fogata.etapa-3 .llama-4 { background: radial-gradient(circle at 50% 20%, #fff176, #ffecb3 30%, #ffcc80 60%, #ff9800); }
-
-.fogata.etapa-4 .llama-1 { background: radial-gradient(circle at 30% 40%, #ffd54f, #ffb74d 40%, #ff7043 70%, #f4511e); }
-.fogata.etapa-4 .llama-2 { background: radial-gradient(circle at 40% 30%, #ffe082, #ffcc80 40%, #ff8a65 70%, #e64a19); }
-.fogata.etapa-4 .llama-3 { background: radial-gradient(circle at 50% 20%, #ffecb3, #ffd54f 30%, #ffa726 60%, #ff6d00); }
-.fogata.etapa-4 .llama-4 { background: radial-gradient(circle at 50% 20%, #ffee58, #ffecb3 30%, #ffcc80 60%, #ff9800); }
-
-.fogata.etapa-5 .llama-1 { background: radial-gradient(circle at 30% 40%, #ffb74d, #ff8a65 40%, #f4511e 70%, #d84315); }
-.fogata.etapa-5 .llama-2 { background: radial-gradient(circle at 40% 30%, #ffcc80, #ffa726 40%, #f4511e 70%, #bf360c); }
-.fogata.etapa-5 .llama-3 { background: radial-gradient(circle at 50% 20%, #ffe082, #ff9800 30%, #e64a19 60%, #9c27b0); }
-.fogata.etapa-5 .llama-4 { background: radial-gradient(circle at 50% 20%, #ffd54f, #ff7043 30%, #d84315 60%, #7b1fa2); }
-
-.fogata.etapa-6 .llama-1 { background: radial-gradient(circle at 30% 40%, #ffa726, #ff8a65 40%, #f4511e 70%, #d84315); }
-.fogata.etapa-6 .llama-2 { background: radial-gradient(circle at 40% 30%, #ffb74d, #ffa726 40%, #f4511e 70%, #bf360c); }
-.fogata.etapa-6 .llama-3 { background: radial-gradient(circle at 50% 20%, #ffcc80, #ff9800 30%, #e64a19 60%, #9c27b0); }
-.fogata.etapa-6 .llama-4 { background: radial-gradient(circle at 50% 20%, #ffb74d, #ff7043 30%, #d84315 60%, #7b1fa2); }
-
-.fogata.etapa-7 .llama-1 { background: radial-gradient(circle at 30% 40%, #ff9800, #ff8a65 40%, #f4511e 70%, #d84315); }
-.fogata.etapa-7 .llama-2 { background: radial-gradient(circle at 40% 30%, #ffa726, #ffa726 40%, #f4511e 70%, #bf360c); }
-.fogata.etapa-7 .llama-3 { background: radial-gradient(circle at 50% 20%, #ffb74d, #ff9800 30%, #e64a19 60%, #9c27b0); }
-.fogata.etapa-7 .llama-4 { background: radial-gradient(circle at 50% 20%, #ffa726, #ff7043 30%, #d84315 60%, #7b1fa2); }
-
-.fogata.etapa-8 .llama-1 { background: radial-gradient(circle at 30% 40%, #ff8a65, #ff7043 40%, #f4511e 70%, #d84315); }
-.fogata.etapa-8 .llama-2 { background: radial-gradient(circle at 40% 30%, #ff9800, #ff8a65 40%, #f4511e 70%, #bf360c); }
-.fogata.etapa-8 .llama-3 { background: radial-gradient(circle at 50% 20%, #ffa726, #ff7043 30%, #e64a19 60%, #9c27b0); }
-.fogata.etapa-8 .llama-4 { background: radial-gradient(circle at 50% 20%, #ff8a65, #ff5722 30%, #d84315 60%, #7b1fa2); }
-
-.fogata.etapa-9 .llama-1 { background: radial-gradient(circle at 30% 40%, #ff7043, #ff5722 40%, #f4511e 70%, #d84315); }
-.fogata.etapa-9 .llama-2 { background: radial-gradient(circle at 40% 30%, #ff8a65, #ff7043 40%, #f4511e 70%, #bf360c); }
-.fogata.etapa-9 .llama-3 { background: radial-gradient(circle at 50% 20%, #ff9800, #ff5722 30%, #e64a19 60%, #9c27b0); }
-.fogata.etapa-9 .llama-4 { background: radial-gradient(circle at 50% 20%, #ff7043, #ff3d00 30%, #d84315 60%, #7b1fa2); }
-
-.fogata.etapa-10 .llama-1 { background: radial-gradient(circle at 30% 40%, #ff5722, #f4511e 40%, #d84315 70%, #9c27b0); }
-.fogata.etapa-10 .llama-2 { background: radial-gradient(circle at 40% 30%, #ff7043, #e64a19 40%, #bf360c 70%, #8e24aa); }
-.fogata.etapa-10 .llama-3 { background: radial-gradient(circle at 50% 20%, #ff8a65, #d84315 30%, #9c27b0 60%, #6a1b9a); }
-.fogata.etapa-10 .llama-4 { background: radial-gradient(circle at 50% 20%, #ff5722, #bf360c 30%, #7b1fa2 60%, #5e35b1); }
-
-.fogata.etapa-11 .llama-1 { background: radial-gradient(circle at 30% 40%, #f4511e, #e64a19 40%, #d84315 70%, #8e24aa); }
-.fogata.etapa-11 .llama-2 { background: radial-gradient(circle at 40% 30%, #ff5722, #d84315 40%, #bf360c 70%, #7b1fa2); }
-.fogata.etapa-11 .llama-3 { background: radial-gradient(circle at 50% 20%, #ff7043, #bf360c 30%, #8e24aa 60%, #5e35b1); }
-.fogata.etapa-11 .llama-4 { background: radial-gradient(circle at 50% 20%, #f4511e, #9c27b0 30%, #6a1b9a 60%, #4527a0); }
-
-.fogata.etapa-12 .llama-1 { background: radial-gradient(circle at 30% 40%, #e64a19, #d84315 40%, #bf360c 70%, #7b1fa2); }
-.fogata.etapa-12 .llama-2 { background: radial-gradient(circle at 40% 30%, #f4511e, #bf360c 40%, #9c27b0 70%, #6a1b9a); }
-.fogata.etapa-12 .llama-3 { background: radial-gradient(circle at 50% 20%, #ff5722, #9c27b0 30%, #7b1fa2 60%, #5e35b1); }
-.fogata.etapa-12 .llama-4 { background: radial-gradient(circle at 50% 20%, #e64a19, #8e24aa 30%, #5e35b1 60%, #4527a0); }
-
-.fogata.etapa-13 .llama-1 { background: radial-gradient(circle at 30% 40%, #d84315, #bf360c 40%, #9c27b0 70%, #6a1b9a); }
-.fogata.etapa-13 .llama-2 { background: radial-gradient(circle at 40% 30%, #e64a19, #9c27b0 40%, #8e24aa 70%, #5e35b1); }
-.fogata.etapa-13 .llama-3 { background: radial-gradient(circle at 50% 20%, #f4511e, #8e24aa 30%, #6a1b9a 60%, #5e35b1); }
-.fogata.etapa-13 .llama-4 { background: radial-gradient(circle at 50% 20%, #d84315, #7b1fa2 30%, #5e35b1 60%, #4527a0); }
-
-.fogata.etapa-14 .llama-1 { background: radial-gradient(circle at 30% 40%, #bf360c, #9c27b0 40%, #8e24aa 70%, #5e35b1); }
-.fogata.etapa-14 .llama-2 { background: radial-gradient(circle at 40% 30%, #d84315, #8e24aa 40%, #7b1fa2 70%, #5e35b1); }
-.fogata.etapa-14 .llama-3 { background: radial-gradient(circle at 50% 20%, #e64a19, #7b1fa2 30%, #6a1b9a 60%, #5e35b1); }
-.fogata.etapa-14 .llama-4 { background: radial-gradient(circle at 50% 20%, #bf360c, #6a1b9a 30%, #5e35b1 60%, #4527a0); }
-
-.fogata.etapa-15 .llama-1 { background: radial-gradient(circle at 30% 40%, #9c27b0, #8e24aa 40%, #7b1fa2 70%, #5e35b1); }
-.fogata.etapa-15 .llama-2 { background: radial-gradient(circle at 40% 30%, #8e24aa, #7b1fa2 40%, #6a1b9a 70%, #5e35b1); }
-.fogata.etapa-15 .llama-3 { background: radial-gradient(circle at 50% 20%, #7b1fa2, #6a1b9a 30%, #5e35b1 60%, #4527a0); }
-.fogata.etapa-15 .llama-4 { background: radial-gradient(circle at 50% 20%, #6a1b9a, #5e35b1 30%, #4527a0 60%, #311b92); }
-
-.fogata.etapa-16 .llama-1 { background: radial-gradient(circle at 30% 40%, #8e24aa, #7b1fa2 40%, #6a1b9a 70%, #5e35b1); }
-.fogata.etapa-16 .llama-2 { background: radial-gradient(circle at 40% 30%, #7b1fa2, #6a1b9a 40%, #5e35b1 70%, #4527a0); }
-.fogata.etapa-16 .llama-3 { background: radial-gradient(circle at 50% 20%, #6a1b9a, #5e35b1 30%, #4527a0 60%, #3949ab); }
-.fogata.etapa-16 .llama-4 { background: radial-gradient(circle at 50% 20%, #5e35b1, #4527a0 30%, #3949ab 60%, #303f9f); }
-
-.fogata.etapa-17 .llama-1 { background: radial-gradient(circle at 30% 40%, #7b1fa2, #6a1b9a 40%, #5e35b1 70%, #4527a0); }
-.fogata.etapa-17 .llama-2 { background: radial-gradient(circle at 40% 30%, #6a1b9a, #5e35b1 40%, #4527a0 70%, #3949ab); }
-.fogata.etapa-17 .llama-3 { background: radial-gradient(circle at 50% 20%, #5e35b1, #4527a0 30%, #3949ab 60%, #303f9f); }
-.fogata.etapa-17 .llama-4 { background: radial-gradient(circle at 50% 20%, #4527a0, #3949ab 30%, #303f9f 60%, #283593); }
-
-.fogata.etapa-18 .llama-1 { background: radial-gradient(circle at 30% 40%, #6a1b9a, #5e35b1 40%, #4527a0 70%, #3949ab); }
-.fogata.etapa-18 .llama-2 { background: radial-gradient(circle at 40% 30%, #5e35b1, #4527a0 40%, #3949ab 70%, #303f9f); }
-.fogata.etapa-18 .llama-3 { background: radial-gradient(circle at 50% 20%, #4527a0, #3949ab 30%, #303f9f 60%, #283593); }
-.fogata.etapa-18 .llama-4 { background: radial-gradient(circle at 50% 20%, #3949ab, #303f9f 30%, #283593 60%, #1a237e); }
-
-.fogata.etapa-19 .llama-1 { background: radial-gradient(circle at 30% 40%, #5e35b1, #4527a0 40%, #3949ab 70%, #303f9f); }
-.fogata.etapa-19 .llama-2 { background: radial-gradient(circle at 40% 30%, #4527a0, #3949ab 40%, #303f9f 70%, #283593); }
-.fogata.etapa-19 .llama-3 { background: radial-gradient(circle at 50% 20%, #3949ab, #303f9f 30%, #283593 60%, #1a237e); }
-.fogata.etapa-19 .llama-4 { background: radial-gradient(circle at 50% 20%, #303f9f, #283593 30%, #1a237e 60%, #0d47a1); }
-
-/* Animaciones de llamas */
-@keyframes flame1 {
-    0%, 100% { transform: translateX(-50%) scaleY(1) scaleX(1); }
-    25% { transform: translateX(-48%) scaleY(1.1) scaleX(0.95); }
-    50% { transform: translateX(-52%) scaleY(1.2) scaleX(1.05); }
-    75% { transform: translateX(-50%) scaleY(1.05) scaleX(0.98); }
-}
-
-@keyframes flame2 {
-    0%, 100% { transform: translateX(-50%) scaleY(1) scaleX(1); }
-    25% { transform: translateX(-52%) scaleY(1.15) scaleX(0.97); }
-    50% { transform: translateX(-48%) scaleY(1.25) scaleX(1.07); }
-    75% { transform: translateX(-50%) scaleY(1.1) scaleX(0.95); }
-}
-
-@keyframes flame3 {
-    0%, 100% { transform: translateX(-50%) scaleY(1) scaleX(1); }
-    25% { transform: translateX(-49%) scaleY(1.2) scaleX(0.98); }
-    50% { transform: translateX(-51%) scaleY(1.3) scaleX(1.08); }
-    75% { transform: translateX(-50%) scaleY(1.15) scaleX(0.93); }
-}
-
-@keyframes flame4 {
-    0%, 100% { transform: translateX(-50%) scaleY(1) scaleX(1); }
-    50% { transform: translateX(-50%) scaleY(1.4) scaleX(1.1); }
-}
-
-/* Centro de la fogata */
-.centro {
-    position: absolute;
-    bottom: 10%;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 15%;
-    height: 15%;
-    background: #000;
-    border-radius: 50%;
-    z-index: 2;
-    transition: all 1s ease;
-}
-
-/* Resplandor alrededor del fuego */
-.resplandor {
-    position: absolute;
-    bottom: -10%;
-    left: 50%;
-    transform: translateX(-50%);
-    width: 200%;
-    height: 50%;
-    border-radius: 50%;
-    z-index: 1;
-    animation: glow 3s infinite alternate;
-    transition: all 1s ease;
-    opacity: 0.7;
-}
-
-/* Colores de resplandor por etapa */
-.fogata.etapa-0 .resplandor { background: radial-gradient(circle, rgba(255, 140, 0, 0.3) 0%, rgba(255, 80, 0, 0.2) 40%, transparent 70%); }
-.fogata.etapa-1 .resplandor { background: radial-gradient(circle, rgba(255, 140, 0, 0.32) 0%, rgba(255, 80, 0, 0.22) 40%, transparent 70%); }
-.fogata.etapa-2 .resplandor { background: radial-gradient(circle, rgba(255, 140, 0, 0.34) 0%, rgba(255, 80, 0, 0.24) 40%, transparent 70%); }
-.fogata.etapa-3 .resplandor { background: radial-gradient(circle, rgba(255, 140, 0, 0.36) 0%, rgba(255, 80, 0, 0.26) 40%, transparent 70%); }
-.fogata.etapa-4 .resplandor { background: radial-gradient(circle, rgba(255, 140, 0, 0.38) 0%, rgba(255, 80, 0, 0.28) 40%, transparent 70%); }
-.fogata.etapa-5 .resplandor { background: radial-gradient(circle, rgba(255, 100, 0, 0.4) 0%, rgba(255, 60, 0, 0.3) 40%, transparent 70%); }
-.fogata.etapa-6 .resplandor { background: radial-gradient(circle, rgba(255, 100, 0, 0.42) 0%, rgba(255, 60, 0, 0.32) 40%, transparent 70%); }
-.fogata.etapa-7 .resplandor { background: radial-gradient(circle, rgba(255, 100, 0, 0.44) 0%, rgba(255, 60, 0, 0.34) 40%, transparent 70%); }
-.fogata.etapa-8 .resplandor { background: radial-gradient(circle, rgba(255, 100, 0, 0.46) 0%, rgba(255, 60, 0, 0.36) 40%, transparent 70%); }
-.fogata.etapa-9 .resplandor { background: radial-gradient(circle, rgba(255, 100, 0, 0.48) 0%, rgba(255, 60, 0, 0.38) 40%, transparent 70%); }
-.fogata.etapa-10 .resplandor { background: radial-gradient(circle, rgba(255, 60, 0, 0.5) 0%, rgba(255, 30, 0, 0.3) 40%, transparent 70%); }
-.fogata.etapa-11 .resplandor { background: radial-gradient(circle, rgba(255, 60, 0, 0.52) 0%, rgba(255, 30, 0, 0.32) 40%, transparent 70%); }
-.fogata.etapa-12 .resplandor { background: radial-gradient(circle, rgba(255, 60, 0, 0.54) 0%, rgba(255, 30, 0, 0.34) 40%, transparent 70%); }
-.fogata.etapa-13 .resplandor { background: radial-gradient(circle, rgba(255, 60, 0, 0.56) 0%, rgba(255, 30, 0, 0.36) 40%, transparent 70%); }
-.fogata.etapa-14 .resplandor { background: radial-gradient(circle, rgba(255, 60, 0, 0.58) 0%, rgba(255, 30, 0, 0.38) 40%, transparent 70%); }
-.fogata.etapa-15 .resplandor { background: radial-gradient(circle, rgba(180, 40, 180, 0.5) 0%, rgba(140, 20, 140, 0.3) 40%, transparent 70%); }
-.fogata.etapa-16 .resplandor { background: radial-gradient(circle, rgba(170, 50, 190, 0.52) 0%, rgba(150, 30, 150, 0.32) 40%, transparent 70%); }
-.fogata.etapa-17 .resplandor { background: radial-gradient(circle, rgba(160, 60, 200, 0.54) 0%, rgba(160, 40, 160, 0.34) 40%, transparent 70%); }
-.fogata.etapa-18 .resplandor { background: radial-gradient(circle, rgba(150, 70, 210, 0.56) 0%, rgba(170, 50, 170, 0.36) 40%, transparent 70%); }
-.fogata.etapa-19 .resplandor { background: radial-gradient(circle, rgba(0, 150, 255, 0.6) 0%, rgba(0, 100, 200, 0.4) 40%, transparent 70%); }
-
-@keyframes glow {
-    0% { opacity: 0.6; transform: translateX(-50%) scale(1); }
-    100% { opacity: 0.9; transform: translateX(-50%) scale(1.2); }
-}
-
-/* Efecto de chispas */
-.chispas {
-    position: absolute;
-    top: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    z-index: 10;
-}
-
-/* 😊✋ Carita y manita */
-.carita-con-manita {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    font-size: 0.6em;
-    z-index: 20;
+.racha .manita, .racha .carita {
     display: none;
-    align-items: center;
-    gap: 3px;
-}
-
-.fogata.saludar .carita-con-manita {
-    display: inline-flex;
-    animation: saludar 2s ease-out forwards;
-}
-
-.carita {
-    font-size: 1.8em;
-    text-shadow: 0 0 10px #ff9800;
-}
-
-.manita {
-    display: inline-block;
-    margin-left: 5px;
-    font-size: 1.5em;
-    animation: saludar-mano 2s ease-in-out;
-    transform-origin: 60% 60%;
-}
-
-@keyframes saludar {
-    0%   { opacity: 0; transform: translate(-50%, -50%) scale(0.3); }
-    20%  { opacity: 1; transform: translate(-50%, -100%) scale(1.2); }
-    40%, 70% { transform: translate(-50%, -120%) scale(1.2); }
-    100% { opacity: 0; transform: translate(-50%, -150%) scale(0.5); }
-}
-
-@keyframes saludar-mano {
-    0%, 100% { transform: rotate(0deg); }
-    20%  { transform: rotate(30deg); }
-    40%  { transform: rotate(-20deg); }
-    60%  { transform: rotate(15deg); }
-    80%  { transform: rotate(-10deg); }
 }

--- a/PI-main/static/css/registrarse.css
+++ b/PI-main/static/css/registrarse.css
@@ -1,11 +1,69 @@
 body {
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    height: 100vh;
     font-family: 'Montserrat', sans-serif;
     background: #ffffff;
     margin: 0;
+}
+
+.navbar {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: #b39ddb;
+    padding: 10px 30px;
+    font-weight: bold;
+}
+
+.navbar a {
+    color: #4545EA;
+    text-decoration: none;
+    margin: 0 10px;
+    font-size: 25px;
+    font-weight: bolder;
+}
+
+.navbar a:hover {
+    transform: scale(1.1) translateY(-3px);
+    color: white;
+}
+
+.navbar .logo-nav {
+    height: 50px;
+}
+
+.open-modal-btn {
+    background: transparent;
+    border: none;
+    padding: 0;
+    margin: 0;
+    box-shadow: none;
+    outline: none;
+    cursor: default;
+}
+
+.open-modal-btn:focus,
+.open-modal-btn:hover {
+    border: none;
+    box-shadow: none;
+    outline: none;
+}
+
+@keyframes fuego {
+    0%   { color: #ff5722; text-shadow: 0 0 20px #ff5722; }
+    50%  { color: #ff9800; text-shadow: 0 0 20px #ff9800; }
+    100% { color: #ff5722; text-shadow: 0 0 20px #ff5722; }
+}
+.racha {
+    font-weight: bold;
+    font-size: 24px;
+    animation: fuego 1.5s infinite alternate;
+}
+.racha.gold {
+    color: gold;
+    animation: none;
+    text-shadow: 0 0 15px gold;
+}
+.racha .manita, .racha .carita {
+    display: none;
 }
 
 .register-container {
@@ -17,6 +75,7 @@ body {
     max-width: 600px;
     width: 100%;
     border: 2px solid #dddddd;
+    margin: 80px auto;
 }
 
 .logo {

--- a/PI-main/templates/AcActividad.html
+++ b/PI-main/templates/AcActividad.html
@@ -8,25 +8,8 @@
 </head>
 
 <body>
+    {% include 'navbar.html' %}
     <div class="container">
-        <nav class="navbar">
-            <div class="box">
-                <button class="open-modal-btn">
-                    <span id="racha-fuego" class="racha">
-                        {{ racha }} 🔥
-                        <span class="manita">✋</span>
-                        <span class="carita">😊</span>
-                    </span>
-                </button>
-            </div>
-            <a href="#">Perfil</a>
-            <a href="#">Rutinas</a>
-            <img src="{{ url_for('static', filename='img/logo.png') }}" alt="Logo" class="logo-nav">
-            </a>
-            <a href="{{ url_for('actividades') }}">Actividades</a>
-            <a href="#">Cerrar Sesión</a>
-        </nav>
-
         <div class="info">
             {% with mensajes = get_flashed_messages() %}
                 {% if mensajes %}
@@ -47,7 +30,7 @@
         </div>
 
         <div class="crear-actividad">
-            <form method="POST" action="{{ url_for('editar_actividad', id=actividad.id) }}">
+            <form method="POST" action="{{ url_for('main.editar_actividad', id=actividad.id) }}">
                 <img id="imagen-actividad" src="../{{ actividad.imagen }}"
                     alt="Imagen de actividad" class="imagen-actividad">
 

--- a/PI-main/templates/NvActividad.html
+++ b/PI-main/templates/NvActividad.html
@@ -8,25 +8,8 @@
     </head>
 
     <body>
+        {% include 'navbar.html' %}
         <div class="container">
-            <nav class="navbar">
-                <div class="box">
-                    <button class="open-modal-btn">
-                        <span id="racha-fuego" class="racha" >
-                            {{ racha }} 🔥
-                            <span class="manita">✋</span>
-                            <span class="carita">😊</span>
-                        </span>
-
-                    </button>
-                </div>
-                <a href="#">Perfil</a>
-                <a href="#">Rutinas</a>
-                    <img src="{{ url_for('static', filename='img/logo.png') }}" alt="Logo" class="logo-nav">
-                </a>
-                <a href="{{ url_for('actividades') }}">Actividades</a>
-                <a href="#">Cerrar Sesión</a>
-            </nav>
             <div class="info">
                 {% with mensajes = get_flashed_messages() %}
                     {% if mensajes %}
@@ -48,7 +31,7 @@
             </div>
             <div class="crear-actividad">
 
-                <form method="POST" action="{{ url_for('PostNvActividad') }}">
+                <form method="POST" action="{{ url_for('main.PostNvActividad') }}">
                 <img id="imagen-actividad" src="{{ url_for('static', filename='img/imagen1.png') }}"
                     alt="Imagen de actividad" class="imagen-actividad">
 

--- a/PI-main/templates/actividades.html
+++ b/PI-main/templates/actividades.html
@@ -20,47 +20,18 @@
             });
         </script>
     {% endif %}
-    <nav class="navbar">
-        <div class="box">
-            <div class="fogata-container">
-                <div id="fogata" class="fogata">
-                    <div class="llamas">
-                        <div class="llama llama-1"></div>
-                        <div class="llama llama-2"></div>
-                        <div class="llama llama-3"></div>
-                        <div class="llama llama-4"></div>
-                        <div class="centro"></div>
-                        <div class="chispas"></div>
-                    </div>
-                    <div class="resplandor"></div>
-                    <div class="carita-con-manita">
-                        <span class="carita">😊</span>
-                        <span class="manita">✋</span>
-                    </div>
-                </div>
-                <div class="racha-info">
-                    <span>Días:</span>
-                    <span id="dias-racha" class="dias-racha">{{ racha }}</span>
-                </div>
-            </div>
-        </div>
-        <a href="{{url_for('rutinas')}}">Rutinas</a>
-        <img src="{{ url_for('static', filename='img/logo.png') }}" alt="Logo" class="logo-nav">
-        <a href="{{ url_for('actividades') }}">Actividades</a>
-        <a href="{{ url_for('login') }}">Cerrar Sesión</a>
-    </nav>
-
+    {% include 'navbar.html' %}
     {% if errores and errores.no_actividades %}
         <div class="calendario-header">
             <h2>No hay actividades para mostrar</h2>
-            <a href="{{ url_for('NvActividad') }}" class="crear-actividad-btn"><h2>Crear mi nueva actividad</h2></a>
+            <a href="{{ url_for('main.NvActividad') }}" class="crear-actividad-btn"><h2>Crear mi nueva actividad</h2></a>
         </div>
     {% elif tareas_importantes|length > 0 %}
         <div class="Tareas_Dia">
             <section class="calendario">
                 <div class="calendario-header">
                     <h2>Tareas por completar</h2>
-                    <a href="{{ url_for('NvActividad') }}" class="agregar-btn">Agregar</a>
+                    <a href="{{ url_for('main.NvActividad') }}" class="agregar-btn">Agregar</a>
                 </div>
                 <div class="tarjetas calendario-grid">
                     {% for tarea in tareas_importantes %}
@@ -69,13 +40,10 @@
                         <h3>{{ tarea.titulo }}</h3>
                         <span>{{ tarea.hora }}</span>
                         <p class="descripcion">{{ tarea.descripcion }}</p>
-                        <!-- añadir onclick para cambiar el estado de la tarea en la base de datos -->
-                        <input type="checkbox" class="custom-checkbox" {% if tarea.completada %}checked{% endif %}> 
-
+                        <input type="checkbox" class="custom-checkbox" {% if tarea.completada %}checked{% endif %} data-idx="{{ loop.index0 }}">
                         <div class="acciones">
                             <a href="javascript:void(0)" class="btn-eliminar" onclick="confirmarEliminacion('{{ tarea.id }}')">Eliminar</a>
-
-                            <a href="{{ url_for('editar_actividad', id=tarea.id) }}" class="btn-actualizar">Actualizar</a>
+                            <a href="{{ url_for('main.editar_actividad', id=tarea.id) }}" class="btn-actualizar">Actualizar</a>
                         </div>
                     </div>
                     {% endfor %}
@@ -88,109 +56,44 @@
         </div>
     {% endif %}
 
+    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11.22.2/dist/sweetalert2.all.min.js"></script>
     <script>
-        let rachajs = 0; // Inicializar racha
-        let color_racha = 'default'; // Inicializar color de racha
-
-        // const checkboxes = document.querySelectorAll('.tarea-checkbox');
         const checkboxes = document.querySelectorAll('.custom-checkbox');
-
         checkboxes.forEach(checkbox => {
             checkbox.addEventListener('change', function () {
                 const tarea_completada = Array.from(checkboxes)
                     .filter(cbx => cbx.checked)
                     .map(cbx => cbx.getAttribute('data-idx'));
-
-                fetch('/actualizar_tarea', {
+                fetch('{{ url_for('main.actualizar_tarea') }}', {
                     method: 'POST',
                     headers: {
                         'Content-Type': 'application/json'
                     },
                     body: JSON.stringify({ tarea_completada: tarea_completada })
                 })
-                    .then(response => response.json())
-                    .then(data => {
-                        document.querySelector('#dias-racha').innerText = data.racha;
-                        actualizarFogata(data.racha);
-                    });
+                .then(response => response.json())
+                .then(data => {
+                    document.querySelector('#racha-fuego').innerText = data.racha + ' 🔥';
+                });
             });
         });
 
-        function actualizarFogata(racha) {
-            const fogata = document.getElementById('fogata');
-            // Calcular fase (cada 10 días de racha es una fase)
-            const fase = Math.min(Math.floor(racha / 10), 19);
-            fogata.className = `fogata etapa-${fase}`;
-            
-            // Efecto especial cada 10 días (nueva fase)
-            if (racha % 10 === 0 && racha > 0) {
-                fogata.classList.add('saludar');
-                setTimeout(() => fogata.classList.remove('saludar'), 2000);
-                crearChispas(15 + fase);
-            }
+        function confirmarEliminacion(id) {
+            id = parseInt(id);
+            Swal.fire({
+                title: 'Confirmar eliminación',
+                text: '¿Estás seguro de que deseas eliminar la tarea?',
+                icon: 'warning',
+                showCancelButton: true,
+                confirmButtonText: 'Eliminar',
+                cancelButtonText: 'Cancelar',
+                reverseButtons: true
+            }).then((result) => {
+                if (result.isConfirmed) {
+                    window.location.href = "{{ url_for('main.eliminar_actividad', id='__ID__') }}".replace('__ID__', id);
+                }
+            });
         }
-
-        function crearChispas(cantidad) {
-            const fogata = document.getElementById('fogata');
-            const chispasContainer = fogata.querySelector('.chispas');
-            if (!chispasContainer) return;
-            
-            const racha = parseInt(document.querySelector('#dias-racha').innerText);
-            const fase = Math.min(Math.floor(racha / 10), 19);
-            
-            for (let i = 0; i < cantidad; i++) {
-                const spark = document.createElement('div');
-                spark.className = 'spark';
-                
-                // Posición y animación aleatoria
-                const posX = (Math.random() - 0.5) * 100;
-                const duration = 0.8 + Math.random() * 1.2;
-                const delay = Math.random() * 0.5;
-                const color = fase >= 15 ? 
-                    (Math.random() > 0.5 ? '#4fc3f7' : '#81d4fa') : 
-                    (fase >= 10 ? 
-                        (Math.random() > 0.5 ? '#ff8a65' : '#ff5722') : 
-                        (Math.random() > 0.5 ? '#ffecb3' : '#ffcc80'));
-                
-                spark.style.cssText = `position: absolute; width: ${2 + Math.random() * 3}px; height: ${2 + Math.random() * 3}px; background: ${color}; border-radius: 50%; bottom: 40%; left: 50%; opacity: 0; box-shadow: 0 0 5px ${fase >= 15 ? '#00bcd4' : (fase >= 10 ? '#ff3d00' : '#ff9800')};`;
-
-                // Animación de la chispa
-                const keyframes = `@keyframes spark-fly-${i} { 0% { transform: translate(0, 0); opacity: 1; } 100% { transform: translate(${posX}px, -${200 + Math.random() * 100}px); opacity: 0; } }`;
-
-                const style = document.createElement('style');
-                style.textContent = keyframes;
-                document.head.appendChild(style);
-                
-                spark.style.animation = `spark-fly-${i} ${duration}s ease-in ${delay}s forwards`;
-                chispasContainer.appendChild(spark);
-            }
-        }
-
-        // Inicializar fogata con la racha actual
-        actualizarFogata(rachajs);
-    </script>
-
-    <!-- <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11"></script> -->
-    <!-- link para sweetalert -->
-    <script src="https://cdn.jsdelivr.net/npm/sweetalert2@11.22.2/dist/sweetalert2.all.min.js"></script>
-
-    <script>
-    function confirmarEliminacion(id) {
-        id = parseInt(id);
-        Swal.fire({
-            title: 'Confirmar eliminación',
-            text: '¿Estás seguro de que deseas eliminar la tarea?',
-            icon: 'warning',
-            showCancelButton: true,  // Muestra el botón "Cancelar"
-            confirmButtonText: 'Eliminar',
-            cancelButtonText: 'Cancelar',
-            reverseButtons: true  // Cambia el orden de los botones (primero el "Cancelar")
-        }).then((result) => {
-            if (result.isConfirmed) {
-                window.location.href = "/eliminar_actividad/" + id;
-            }
-        });
-    }
     </script>
 </body>
 

--- a/PI-main/templates/login.html
+++ b/PI-main/templates/login.html
@@ -22,7 +22,7 @@
             {% endif %}
         {% endwith %}
         
-        <form method="POST" action="{{ url_for('login') }}">
+        <form method="POST" action="{{ url_for('main.login') }}">
             <input type="email" name="email" placeholder="Email" required>
             <div class="password-container">
                 <input type="password" name="password" placeholder="Contraseña" id="pwd" required>
@@ -30,7 +30,7 @@
             </div>
             <button type="submit">Iniciar Sesión</button>
         </form>
-        <p class="register-link">¿No tienes cuenta? <a href="{{ url_for('registrarse') }}">Regístrate</a></p>
+        <p class="register-link">¿No tienes cuenta? <a href="{{ url_for('main.registrarse') }}">Regístrate</a></p>
     </div>
 </body>
 </html>

--- a/PI-main/templates/navbar.html
+++ b/PI-main/templates/navbar.html
@@ -1,0 +1,16 @@
+<nav class="navbar">
+  <div class="box">
+    <button class="open-modal-btn">
+      <span id="racha-fuego" class="racha" style="color: {{ color_racha }}">
+        {{ racha }} 🔥
+        <span class="manita">✋</span>
+        <span class="carita">😊</span>
+      </span>
+    </button>
+  </div>
+  <a href="{{ url_for('main.perfil') }}">Perfil</a>
+  <a href="{{ url_for('main.rutinas') }}">Rutinas</a>
+  <img src="{{ url_for('static', filename='img/logo.png') }}" alt="Logo" class="logo-nav">
+  <a href="{{ url_for('main.actividades') }}">Actividades</a>
+  <a href="{{ url_for('main.login') }}">Cerrar Sesión</a>
+</nav>

--- a/PI-main/templates/perfil.html
+++ b/PI-main/templates/perfil.html
@@ -9,27 +9,13 @@
 </head>
 <body>
     <!-- Barra superior -->
-    <nav class="navbar">
-        <div class="box">
-            <button class="open-modal-btn">
-                <span id="racha-fuego" class="racha" style="color: {{ color_racha }}">
-                    {{ racha }} 🔥
-                    <span class="manita">✋</span>
-                    <span class="carita">😊</span>
-                </span>
-            </button>
-        </div>
-        <a href="{{ url_for('rutinas') }}">Rutinas</a>
-        <img src="{{ url_for('static', filename='img/logo.png') }}" alt="Logo" class="logo-nav">
-        <a href="{{ url_for('actividades') }}">Actividades</a>
-        <a href="{{ url_for('login') }}">Cerrar Sesión</a>
-    </nav>
+    {% include 'navbar.html' %}
 
     <main class="contenedor-perfil">
         <!-- Formulario -->
         <section class="editar-perfil">
             <h2>Editar</h2>
-            <form action="{{ url_for('actualizar_perfil') }}" method="POST">
+            <form action="{{ url_for('main.actualizar_perfil') }}" method="POST">
                 <input type="text" placeholder="Nombre" value="{{ usuario.nombre }}" name="nombre">
                 <input type="text" placeholder="Apellido" value="{{ usuario.apellido }}" name="apellido">
                 <input type="password" placeholder="Contraseña" value="{{ usuario.contrasena }}" name="contrasena">
@@ -103,7 +89,7 @@
                 reverseButtons: true  // Cambia el orden de los botones (primero el "Cancelar")
             }).then((result) => {
                 if (result.isConfirmed) {
-                    window.location.href = "/eliminar_cuenta";
+                    window.location.href = "{{ url_for('main.eliminar_cuenta') }}";
                 }
             });
         }

--- a/PI-main/templates/registrarse.html
+++ b/PI-main/templates/registrarse.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='/css/registrarse.css') }}">
 </head>
 <body>
+    {% include 'navbar.html' %}
     <div class="register-container">
         <img src="{{ url_for('static', filename='/img/logo.png') }}" alt="Priority Pulse Logo" class="logo">
         <h3>Sign Up</h3>
@@ -13,7 +14,7 @@
             <p style="color: red;">{{ error }}</p>
         {% endif %}
 
-        <form method="POST" action="{{ url_for('registrarse') }}">
+        <form method="POST" action="{{ url_for('main.registrarse') }}">
             <div class="row">
                 <input type="text" name="Nombre" placeholder="Nombre" >
                 {% if errores and errores.Nombre %}
@@ -37,7 +38,7 @@
             </div>
             <button type="submit">Registrarte</button>
         </form>
-        <p class="login-link">¿Ya tienes una cuenta? <a href="{{ url_for('login') }}">Inicia Sesión</a></p>
+        <p class="login-link">¿Ya tienes una cuenta? <a href="{{ url_for('main.login') }}">Inicia Sesión</a></p>
     </div>
 </body>
 </html>

--- a/PI-main/templates/rutinas.html
+++ b/PI-main/templates/rutinas.html
@@ -8,22 +8,7 @@
 <body>
 
 
-  <nav class="navbar">
-    <div class="box">
-      <button class="open-modal-btn">
-        <span id="racha-fuego" class="racha" style="color: {{ color_racha }}">
-          {{ racha }} 🔥
-          <span class="manita">✋</span>
-          <span class="carita">😊</span>
-        </span>
-      </button>
-    </div>
-    <a href="{{ url_for('perfil') }}">Perfil</a>
-    <a href="{{ url_for('rutinas') }}">Rutinas</a>
-    <img src="{{ url_for('static', filename='img/logo.png') }}" alt="Logo" class="logo-nav">
-    <a href="{{ url_for('actividades') }}">Actividades</a>
-    <a href="{{ url_for('login') }}">Cerrar Sesión</a>
-  </nav>
+  {% include 'navbar.html' %}
 
 
   <main class="contenedor">
@@ -39,7 +24,7 @@
             <li>{{ act }}</li>
           {% endfor %}
         </ul>
-        <a href="{{ url_for('NvActividad') }}?rutina_id={{ rutina.id }}" class="btn">
+        <a href="{{ url_for('main.NvActividad') }}?rutina_id={{ rutina.id }}" class="btn">
           Agregar a Actividades
         </a>
       </div>


### PR DESCRIPTION
## Summary
- centralize common navigation with a reusable Jinja navbar and highlight streak flame on every page except login
- convert routes to a `main` blueprint and register it with the Flask app
- trim fire animation CSS and add lean navbar styles across pages

## Testing
- `python -m py_compile PI-main/app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890363b56948328b5fd248d53381932