### PR TITLE
Fix delete activity URL generation

### DIFF
--- a/PI-main/templates/actividades.html
+++ b/PI-main/templates/actividades.html
@@ -90,7 +90,9 @@
                 reverseButtons: true
             }).then((result) => {
                 if (result.isConfirmed) {
-                    window.location.href = "{{ url_for('main.eliminar_actividad', id='__ID__') }}".replace('__ID__', id);
+                    // Generate base URL with a dummy integer and replace it with the real id
+                    const url = "{{ url_for('main.eliminar_actividad', id=0) }}".replace('0', id);
+                    window.location.href = url;
                 }
             });
         }


### PR DESCRIPTION
## Summary
- Resolve invalid literal error in activity deletion by generating base URL with dummy integer and replacing it in JavaScript.

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890397e15bc83288577c50c63f31c3f