### PR TITLE
Improve task icon visibility and accessibility

### DIFF
--- a/PI-main/static/css/actividades.css
+++ b/PI-main/static/css/actividades.css
@@ -1,3 +1,7 @@
+:root {
+    --tarea-icon-size: 48px;
+}
+
 * {
     box-sizing: border-box;
     margin: 0;
@@ -107,8 +111,8 @@ h2{
 
 /* Ícono */
 .icono-tarea {
-    width: 32px;
-    height: 32px;
+    width: var(--tarea-icon-size);
+    height: var(--tarea-icon-size);
     margin-right: 10px;
     object-fit: contain;
 }

--- a/PI-main/templates/actividades.html
+++ b/PI-main/templates/actividades.html
@@ -36,7 +36,7 @@
                 <div class="tarjetas calendario-grid">
                     {% for tarea in tareas_importantes %}
                     <div class="tarjeta {% if tarea.completada %}completada{% endif %}">
-                        <img src="{{ tarea.imagen }}" class="icono-tarea">
+                        <img src="{{ tarea.imagen }}" class="icono-tarea" alt="Icono de {{ tarea.titulo }}">
                         <h3>{{ tarea.titulo }}</h3>
                         <span>{{ tarea.hora }}</span>
                         <p class="descripcion">{{ tarea.descripcion }}</p>


### PR DESCRIPTION
## Summary
- enlarge task icons and make size configurable with CSS variable
- add alt text to task icons for better accessibility

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68903d26e15c8328845553bc4014ebe9